### PR TITLE
wip on unapply

### DIFF
--- a/core/src/main/scala/matryoshka/Recursive.scala
+++ b/core/src/main/scala/matryoshka/Recursive.scala
@@ -165,3 +165,15 @@ import simulacrum.typeclass
   def convertTo[F[_]: Functor, R[_[_]]: Corecursive](t: T[F]): R[F] =
     cata(t)(Corecursive[R].embed[F])
 }
+
+object Recursive {
+
+  object unapplyops {
+    implicit def toAllRecursiveOpsUnapply[A, B](target: A)(implicit U: Funapply[Recursive, A, B]): AllOps[U.M, U.F] = 
+      new AllOps[U.M, U.F] {
+        val self = U.leibniz(target)
+        val typeClassInstance = U.TC
+      }
+  }
+
+}

--- a/core/src/main/scala/matryoshka/funapply.scala
+++ b/core/src/main/scala/matryoshka/funapply.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scalaz.Leibniz.{ ===, refl }
+
+/** Unapply for a typeclass of shape TC[_[_[_]]]. */
+trait Funapply[TC[_[_[_]]], MF, FMF] {
+
+  /** The type constructor */
+  type M[_[_]]
+
+  /** The type that `M` was applied to */
+  type F[_]
+
+  /** The instance of the type class */
+  def TC: TC[M]
+
+  /** Evidence that MF =:= M[F] */
+  def leibniz: MF === M[F]
+
+  /** Evidence that FMF =:= F[M[F]] */
+  def leibnizF: FMF === F[M[F]]
+
+}
+
+object Funapply {
+
+  def apply[TC[_[_[_]]], MF, FMF](implicit U: Funapply[TC, MF, FMF]): U.type {
+    type M[X[_]] = U.M[X]
+    type F[X] = U.F[X]
+  } = U
+
+  implicit def funapply0[TC[_[_[_]]], M0[_[_]], F0[_]](implicit TC0: TC[M0]): Funapply[TC, M0[F0], F0[M0[F0]]] {
+    type M[X[_]] = M0[X]
+    type F[X] = F0[X]
+  } = new Funapply[TC, M0[F0], F0[M0[F0]]] {
+    type M[X[_]] = M0[X]
+    type F[X] = F0[X]
+    def TC: TC[M] = TC0
+    def leibniz = refl
+    def leibnizF = refl
+  }
+
+  implicit def funapply1[TC[_[_[_]]], M0[_[_], _], F0[_], A](implicit TC0: TC[M0[?[_], A]]): Funapply[TC, M0[F0, A], F0[M0[F0, A]]] {
+    type M[X[_]] = M0[X, A]
+    type F[X] = F0[X]
+  } = new Funapply[TC, M0[F0, A], F0[M0[F0, A]]] {
+    type M[X[_]] = M0[X, A]
+    type F[X] = F0[X]
+    def TC: TC[M] = TC0
+    def leibniz = refl
+    def leibnizF = refl
+  }
+
+}

--- a/core/src/main/scala/matryoshka/package.scala
+++ b/core/src/main/scala/matryoshka/package.scala
@@ -390,4 +390,9 @@ package object matryoshka
   implicit def ToCorecursiveOps[T[_[_]]: Corecursive, F[_]](f: F[T[F]]):
       CorecursiveOps[T, F] =
     new CorecursiveOps[T, F](f)
+
+  implicit def ToCorecursiveOpsUnapply[T[_[_]], F[_], TF](f: F[TF])(implicit U: Funapply[Corecursive, TF, F[TF]]):
+    CorecursiveOps[U.M, U.F] = 
+      new CorecursiveOps[U.M, U.F](U.leibnizF(f))(U.TC)
+
 }

--- a/core/src/test/scala/matryoshka/spec.scala
+++ b/core/src/test/scala/matryoshka/spec.scala
@@ -877,5 +877,29 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
     }
   }
 
+  "Funapply for CorecursiveOps" should {
+    "work for Mu" in {
+       List[Mu[List]]().embed
+       true
+    }
+    // stack overflow ... expected?
+    // "work for Nu" in {
+    //    List[Nu[List]]().embed
+    //    true
+    // }
+    "work for Fix" in {
+       List[Fix[List]]().embed
+       true
+    }
+    "work for Free" in {
+       List[Free[List, Int]]().embed
+       true
+    }
+    "work for Cofree" in {
+       List[Cofree[List, Int]]().embed
+       true
+    }
+  }
+
   def expGen = Gen.resize(100, arbFix(arbExp).arbitrary)
 }


### PR DESCRIPTION
Work in progress on unapply. It's weird but it seems to work.

:-1: don't merge ... janky and incomplete.
- This adds a new unapply for type constructors with the shape needed for `Recursive` and `Corecursive`. It has an extra type parameter and an extra proof term to handle `CorecursiveOps` (which wraps an `F[T[F]]` rather than a `T[F]`.

``` scala
scala> List[Cofree[List,Int]]().embed
res6: scalaz.Cofree[[X]List[X],Int] = scalaz.Cofree$$anon$11@180cae55
```
- Beginnings of integration with the Simulacrum stuff (requires another import right now but I'm sure it's fixable).

``` scala
scala> import Recursive.unapplyops._
import Recursive.unapplyops._

scala> Fix[List](Nil).project
res2: List[matryoshka.Fix[[X]List[X]]] = List()

scala> Cofree[List, Int](1, Nil).project
res3: List[scalaz.Cofree[[X]List[X],Int]] = List()
```

Anyway it's not impossible.
